### PR TITLE
Estimate Gas Catch

### DIFF
--- a/src/soltsice.ts
+++ b/src/soltsice.ts
@@ -246,7 +246,7 @@ export module soltsice {
             // tslint:disable-next-line:variable-name
             estimateGas: (${inputsString}): Promise<number> => {
                 return new Promise((resolve, reject) => {
-                    this._instance.${name}.estimateGas(${inputsNamesString}).then((g: any) => resolve(g));
+                    this._instance.${name}.estimateGas(${inputsNamesString}).then((g: any) => resolve(g)).catch((err: any) => reject(err));
                 });
             }
         });


### PR DESCRIPTION
First off, thanks for making this. I'm happy to throw back a commit to this project.

1. While attempting to use the `estimateGas` function and getting a failure, I noticed the `esimateGas` promise was not properly handling the error case.
2. ~While attempting to fix the previous issue, I ran into a cross platform issue with truffle. Simple fix. You can read more here: https://ethereum.stackexchange.com/a/38120~